### PR TITLE
Work around a bad call by npm to speed up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: node_js
 node_js: '4'
+install: npm install --ignore-scripts


### PR DESCRIPTION
we don't need to `npm run build` to run tests, but `npm` goes ahead and
runs `npm prepublish` at `npm install`, because reasons
https://github.com/npm/npm/issues/3059
